### PR TITLE
feat(home_screen): add navigation to stats screen for active child

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -89,6 +89,14 @@ class _HomePageState extends ConsumerState<HomeScreen> {
                         SnackBar(content: Text(l10n.onlyOneProfileExists)));
                   }
                 }
+                else if (value == 'view_stats') {
+                  logger.info("Navigating to StatsScreen for child: ${activeChild.childId}");
+                  Navigator.pushNamed(
+                    context,
+                    AppRoutes.stats,
+                    arguments: {'childUuid': activeChild.childId},
+                  );
+                }
               },
               itemBuilder: (BuildContext context) {
                 final profilesCount = ref
@@ -105,6 +113,17 @@ class _HomePageState extends ConsumerState<HomeScreen> {
                     value: 'switch',
                     enabled: profilesCount > 1, // Disable if only one profile
                     child: Text(l10n.switchChildProfileButton),
+                  ),
+                  const PopupMenuDivider(),
+                  PopupMenuItem<String>(
+                    value: 'view_stats',
+                    child: Row(
+                      children: [
+                        Icon(Icons.bar_chart_outlined, color: theme.colorScheme.primary),
+                        const SizedBox(width: 8),
+                        Text("View Stats"), //TODO: Add to l10n
+                      ],
+                    ),
                   ),
                 ];
               },


### PR DESCRIPTION
Add a new menu item "View Stats" that navigates to the StatsScreen for the active child