### PR TITLE
feat(haptics): add haptic feedback setting and integration

### DIFF
--- a/lib/constants/const.dart
+++ b/lib/constants/const.dart
@@ -14,3 +14,4 @@ const String keyTtsEnabled = 'ttsEnabled';
 const String keySoundEffectsEnabled = 'soundEffectsEnabled';
 const String keyAppLanguage = 'appLanguage';
 const String keyTtsSpeechRate = 'ttsSpeechRate';
+const String keyHapticFeedbackEnabled = 'hapticFeedbackEnabled';

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -176,6 +176,7 @@ abstract class AppLocalizations {
   String get ttsRateSlow;
   String get ttsRateNormal;
   String get ttsRateFast;
+  String get hapticsEnabledSetting;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -55,7 +55,6 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get chooseCorrectColor => 'اختر اللون الصحيح';
 
-
   // Colors
   @override
   String get red => 'أحمر';
@@ -271,4 +270,6 @@ class AppLocalizationsAr extends AppLocalizations {
   String get ttsRateNormal => 'عادي';
   @override
   String get ttsRateFast => 'سريع';
+  @override
+  String get hapticsEnabledSetting => 'تمكين ردود الفعل اللمسية';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -271,4 +271,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get ttsRateNormal => 'Normal';
   @override
   String get ttsRateFast => 'Fast';
+  @override
+  String get hapticsEnabledSetting => 'Enable Haptic Feedback';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -275,4 +275,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get ttsRateNormal => 'Normal';
   @override
   String get ttsRateFast => 'Rapide';
+  @override
+  String get hapticsEnabledSetting => 'Activer le retour haptique';
 }

--- a/lib/providers/global_providers.dart
+++ b/lib/providers/global_providers.dart
@@ -6,6 +6,7 @@ import 'package:pfa/models/game.dart';
 import 'package:pfa/models/user.dart';
 import 'package:pfa/providers/active_child_notifier.dart';
 import 'package:pfa/providers/app_language_notifier.dart';
+import 'package:pfa/providers/haptics_enabled_notifier.dart';
 import 'package:pfa/providers/tts_speech_rate_notifier.dart';
 import 'package:pfa/services/audio_service.dart';
 import 'package:pfa/services/settings_service.dart';
@@ -99,11 +100,11 @@ final initialChildProfilesProvider = FutureProvider<List<Child>>((ref) async {
 });
 
 final activeChildProvider =
-StateNotifierProvider<ActiveChildNotifier, Child?>((ref) {
+    StateNotifierProvider<ActiveChildNotifier, Child?>((ref) {
   return ActiveChildNotifier(ref);
 });
 
-final childServiceProvider = Provider<ChildService>((ref){
+final childServiceProvider = Provider<ChildService>((ref) {
   final childRepository = ref.watch(childRepositoryProvider);
   return ChildService(childRepository: childRepository);
 });
@@ -139,7 +140,7 @@ final gameRepositoryProvider = Provider<GameRepository>((ref) {
 });
 final gameViewModelProvider = StateNotifierProvider.family<GameViewModel,
     GameState, String /* gameId */ >(
-      (ref, gameId) {
+  (ref, gameId) {
     final gameRepo = ref.read(gameRepositoryProvider);
     final sessionRepo = ref.read(gameSessionRepositoryProvider);
     final logger = ref.read(loggingServiceProvider);
@@ -161,12 +162,13 @@ final gameViewModelProvider = StateNotifierProvider.family<GameViewModel,
       sessionRepo,
       ttsService,
       audioService,
+      ref,
     );
   },
 );
 
 final gamesByCategoryProvider =
-FutureProvider.family<List<Game>, GameCategory>((ref, category) async {
+    FutureProvider.family<List<Game>, GameCategory>((ref, category) async {
   final logger = ref.read(loggingServiceProvider);
   logger.debug(
       "gamesByCategoryProvider: Fetching games for category $category...");
@@ -187,7 +189,7 @@ FutureProvider.family<List<Game>, GameCategory>((ref, category) async {
   }
 });
 final sharedPreferencesProvider =
-FutureProvider<SharedPreferences>((ref) async {
+    FutureProvider<SharedPreferences>((ref) async {
   return await SharedPreferences.getInstance();
 });
 
@@ -206,7 +208,7 @@ final ttsEnabledProvider = FutureProvider<bool>((ref) async {
 });
 
 final ttsSpeechRateProvider =
-StateNotifierProvider<TtsSpeechRateNotifier, double>((ref) {
+    StateNotifierProvider<TtsSpeechRateNotifier, double>((ref) {
   final settingsService = ref.watch(settingsServiceProvider);
   final ttsService = ref.watch(ttsServiceProvider);
   final logger = ref.watch(loggingServiceProvider);
@@ -218,7 +220,7 @@ final soundEffectsEnabledProvider = FutureProvider<bool>((ref) async {
 });
 
 final appLanguageProvider =
-StateNotifierProvider<AppLanguageNotifier, AppLanguage>((ref) {
+    StateNotifierProvider<AppLanguageNotifier, AppLanguage>((ref) {
   final settingsService = ref.watch(settingsServiceProvider);
   final logger = ref.watch(loggingServiceProvider);
   return AppLanguageNotifier(settingsService, logger);
@@ -227,4 +229,11 @@ StateNotifierProvider<AppLanguageNotifier, AppLanguage>((ref) {
 final localeProvider = Provider<Locale>((ref) {
   final appLanguage = ref.watch(appLanguageProvider);
   return Locale(appLanguage.code);
+});
+
+final hapticsEnabledProvider =
+    StateNotifierProvider<HapticsEnabledNotifier, bool>((ref) {
+  final settingsService = ref.watch(settingsServiceProvider);
+  final logger = ref.watch(loggingServiceProvider);
+  return HapticsEnabledNotifier(settingsService, logger);
 });

--- a/lib/providers/haptics_enabled_notifier.dart
+++ b/lib/providers/haptics_enabled_notifier.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:pfa/services/logging_service.dart';
+import 'package:pfa/services/settings_service.dart';
+
+class HapticsEnabledNotifier extends StateNotifier<bool> {
+  final SettingsService _settingsService;
+  final LoggingService _logger;
+
+  HapticsEnabledNotifier(this._settingsService, this._logger) : super(true) {
+    _loadInitialState();
+  }
+
+  Future<void> _loadInitialState() async {
+    state = await _settingsService.areHapticsEnabled();
+    _logger.debug("HapticsEnabledNotifier: Initial haptics state loaded: $state");
+  }
+
+  Future<void> setHapticsEnabled(bool isEnabled) async {
+    if (state != isEnabled) {
+      await _settingsService.setHapticsEnabled(isEnabled);
+      state = isEnabled;
+      _logger.info("HapticsEnabledNotifier: Haptics enabled set to $state");
+    }
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -17,6 +17,7 @@ class SettingsScreen extends ConsumerWidget {
     final soundEffectsEnabledAsync = ref.watch(soundEffectsEnabledProvider);
     final currentAppLanguage = ref.watch(appLanguageProvider);
     final currentSpeechRate = ref.watch(ttsSpeechRateProvider);
+    final hapticsEnabled = ref.watch(hapticsEnabledProvider);
 
     return Scaffold(
       appBar: AppBar(title: Text(l10n.settingsTitle)),
@@ -39,7 +40,17 @@ class SettingsScreen extends ConsumerWidget {
             error: (err, st) =>
                 ListTile(title: Text("Error loading TTS setting: $err")),
           ),
+          const Divider(),
 
+          // --- Haptics Enabled Setting ---
+          SwitchListTile(
+            title: Text(l10n.hapticsEnabledSetting),
+            value: hapticsEnabled,
+            onChanged: (bool value) {
+              ref.read(hapticsEnabledProvider.notifier).setHapticsEnabled(value);
+            },
+            secondary: const Icon(Icons.vibration),
+          ),
           const Divider(),
 
           // Sound Effects Setting

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -89,6 +89,21 @@ class SettingsService {
     return enabled;
   }
 
+  Future<void> setHapticsEnabled(bool enabled) async {
+    final prefs = SharedPreferencesAsync();
+    await prefs.setBool(keyHapticFeedbackEnabled, enabled);
+    _logger.info("SettingsService: Haptic feedbacks enabled set to $enabled");
+  }
+
+  Future<bool> areHapticsEnabled({bool defaultValue = true}) async {
+    final prefs = SharedPreferencesAsync();
+    final enabled =
+        await prefs.getBool(keyHapticFeedbackEnabled) ?? defaultValue;
+    _logger.debug(
+        "SettingsService: Retrieved Haptic feedbacks enabled: $enabled (default: $defaultValue)");
+    return enabled;
+  }
+
   // Method to clear all app-specific settings (e.g., on logout or factory reset)
   Future<void> clearAllAppSettings() async {
     final prefs = SharedPreferencesAsync();


### PR DESCRIPTION
Introduce a new setting to enable or disable haptic feedback across the app. This includes:
- Adding a new setting in the settings screen
- Creating a provider to manage the haptic feedback state
- Integrating haptic feedback in the game viewmodel for correct/incorrect answers