### PR TITLE
feat(game): add story continue button and improve camera option layout

### DIFF
--- a/lib/models/screen.dart
+++ b/lib/models/screen.dart
@@ -36,6 +36,7 @@ class Option {
   final String? picturePath;
   final String? audioPath;
   final String? pairId; // Used for Memory games to identify matching pairs
+  final bool isStoryContinueButton;
 
   Option({
     required this.optionId,
@@ -45,6 +46,7 @@ class Option {
     this.audioPath,
     this.isCorrect = false,
     this.pairId,
+    this.isStoryContinueButton = false,
   });
 
   factory Option.fromJson(Map<String, dynamic> json) {
@@ -56,6 +58,7 @@ class Option {
       audioPath: json['audio_url'] as String?,
       isCorrect: json['is_correct'] as bool? ?? false,
       pairId: json['pair_id'] as String?,
+      isStoryContinueButton: json['is_story_continue_button'] as bool? ?? false,
     );
   }
 }

--- a/lib/repositories/game_repository.dart
+++ b/lib/repositories/game_repository.dart
@@ -22,7 +22,7 @@ class GameRepository {
   static const String _screenSelect =
       'screen_id, level_id, screen_number, type, instruction';
   static const String _optionSelect =
-      'option_id, screen_id, label_text, picture_url, is_correct, pair_id';
+      'option_id, screen_id, label_text, picture_url, is_correct, pair_id, is_story_continue_button';
 
   GameRepository(
       {required SupabaseService supabaseService,

--- a/lib/viewmodels/game_viewmodel.dart
+++ b/lib/viewmodels/game_viewmodel.dart
@@ -312,37 +312,46 @@ class GameViewModel extends StateNotifier<GameState> {
   }
 
   void _processMultipleChoiceAnswer(Option selectedOption) {
-    bool? isCorrectCurrently = selectedOption.isCorrect;
     final bool hapticsAreEnabled = _ref.read(hapticsEnabledProvider);
-
-    state =
-        state.copyWith(isCorrect: isCorrectCurrently, clearErrorMessage: true);
-    _recordAttempt(
-        screenId: state.currentScreenData!.screen.screenId,
-        isCorrectAnswer: isCorrectCurrently,
-        timeTakenMs: 1000 // TODO: Fix
-        );
-
-    final feedbackText =
-        isCorrectCurrently == true ? _l10n.correct : _l10n.tryAgain;
-
-    _ttsService.speak(feedbackText);
-    if (isCorrectCurrently == true) {
-      _audioService.playSound(SoundType.correct);
-      if (hapticsAreEnabled) {
-        HapticFeedback.mediumImpact();
-      }
+    if (selectedOption.isStoryContinueButton) {
+      _logger.debug(
+          "Processing story continue button. Moving to next screen directly.");
+      _audioService.playSound(SoundType.uiClick);
+      if (hapticsAreEnabled) HapticFeedback.lightImpact();
+      state = state.copyWith(clearIsCorrect: true, clearErrorMessage: true);
+      moveToNextScreen();
     } else {
-      _audioService.playSound(SoundType.incorrect);
-      if (hapticsAreEnabled) {
-        HapticFeedback.lightImpact();
+      bool? isCorrectCurrently = selectedOption.isCorrect;
+
+      state = state.copyWith(
+          isCorrect: isCorrectCurrently, clearErrorMessage: true);
+      _recordAttempt(
+          screenId: state.currentScreenData!.screen.screenId,
+          isCorrectAnswer: isCorrectCurrently,
+          timeTakenMs: 1000 // TODO: Fix
+          );
+
+      final feedbackText =
+          isCorrectCurrently == true ? _l10n.correct : _l10n.tryAgain;
+
+      _ttsService.speak(feedbackText);
+      if (isCorrectCurrently == true) {
+        _audioService.playSound(SoundType.correct);
+        if (hapticsAreEnabled) {
+          HapticFeedback.mediumImpact();
+        }
+      } else {
+        _audioService.playSound(SoundType.incorrect);
+        if (hapticsAreEnabled) {
+          HapticFeedback.lightImpact();
+        }
       }
-    }
-    if (isCorrectCurrently == true) {
-      // Delay moving to the next screen
-      Timer(const Duration(seconds: 1), () {
-        if (mounted) moveToNextScreen();
-      });
+      if (isCorrectCurrently == true) {
+        // Delay moving to the next screen
+        Timer(const Duration(seconds: 1), () {
+          if (mounted) moveToNextScreen();
+        });
+      }
     }
   }
 


### PR DESCRIPTION
This commit introduces a "story continue" button functionality for multiple-choice screens and refines the UI for screens utilizing camera input for emotion recognition.

Key changes:
- Added `is_story_continue_button` field to `Option` model and database schema.
- Implemented logic in `GameViewModel` to handle story continue buttons, advancing to the next screen directly without correctness evaluation.
- Refactored `GameScreen` to:
    - Display a dedicated layout for emotion camera screens, separating the target emotion option from the camera preview.
    - Improve the visual presentation of feedback messages (correct/incorrect) with updated styling and animations.
    - Make the main content area scrollable to accommodate varying content sizes.
    - Adjusted padding and sizing of UI elements for better visual balance.
- Removed unused `dispose` method from `GameScreen`.